### PR TITLE
platformio support

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -566,7 +566,7 @@ bool OneWire::check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inv
 
 uint16_t OneWire::crc16(const uint8_t* input, uint16_t len, uint16_t crc)
 {
-#if defined(__AVR__)
+#if 0
     for (uint16_t i = 0 ; i < len ; i++) {
         crc = _crc16_update(crc, input[i]);
     }

--- a/library.json
+++ b/library.json
@@ -27,14 +27,5 @@
       "name": "Rob Tillaart",
       "email": "rob.tillaart@gmail.com"
     }
-  ],
-  "dependencies":
-  {
-    "name": "OneWire",
-    "authors": "Paul Stoffregen",
-    "frameworks": "arduino"
-  },
-  "version": "3.7.7",
-  "frameworks": "arduino",
-  "platforms": "*"
+  ]
 }


### PR DESCRIPTION
Исходная библиотека не позволяла скомпилировалать проект. 
Убрал зависимость из json, чтобы избежать ошибки дублирования при линковке.

Также изменил вычисление crc16:

.piolibdeps/DallasTemperature/OneWire.cpp: In static member function 'static uint16_t OneWire::crc16(const uint8_t*, uint16_t, uint16_t)':
.piolibdeps/DallasTemperature/OneWire.cpp:571:42: error: '_crc16_update' was not declared in this scope
crc = _crc16_update(crc, input[i]);
^