### PR TITLE
Fix compilation problems

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -566,7 +566,8 @@ bool OneWire::check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inv
 
 uint16_t OneWire::crc16(const uint8_t* input, uint16_t len, uint16_t crc)
 {
-#if defined(__AVR__)
+//#if defined(__AVR__)
+#if 0
     for (uint16_t i = 0 ; i < len ; i++) {
         crc = _crc16_update(crc, input[i]);
     }

--- a/library.json
+++ b/library.json
@@ -27,14 +27,5 @@
       "name": "Rob Tillaart",
       "email": "rob.tillaart@gmail.com"
     }
-  ],
-  "dependencies":
-  {
-    "name": "OneWire",
-    "authors": "Paul Stoffregen",
-    "frameworks": "arduino"
-  },
-  "version": "3.7.7",
-  "frameworks": "arduino",
-  "platforms": "*"
+  ]
 }


### PR DESCRIPTION
Still have problems!

livello@lserver ~/PROG/lighthub $ pio run -e megaatmega2560

[Mon Mar 12 18:28:42 2018] Processing megaatmega2560 (platform: atmelavr; lib_deps: https://github.com/anklimov/Arduino-Temperature-Control-Library.git, https://github.com/anklimov/DS2482_OneWire, https://github.com/anklimov/DmxSimple, https://github.com/anklimov/httpClient, https://github.com/anklimov/aJson, https://github.com/anklimov/CmdArduino, https://github.com/anklimov/ModbusMaster, https://github.com/anklimov/DMXSerial, https://github.com/anklimov/Ethernet, https://github.com/PaulStoffregen/SPI.git, https://github.com/knolleary/pubsubclient.git, https://github.com/anklimov/Artnet.git, FastLED; board: megaatmega2560; framework: arduino)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
Converting lighthub.ino
/home/livello/PROG/lighthub/lighthub/lighthub.ino:93:0: warning: "wdt_res" redefined
#define wdt_res() watchdogReset()
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:84:0: note: this is the location of the previous definition
#define wdt_res()  wdt_reset()
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:94:0: warning: "wdt_en" redefined
#define wdt_en()
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:82:0: note: this is the location of the previous definition
#define wdt_en()   wdt_enable(WDTO_8S)
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:95:0: warning: "wdt_dis" redefined
#define wdt_dis()
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:83:0: note: this is the location of the previous definition
#define wdt_dis()  wdt_disable()
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:103:0: warning: "wdt_res" redefined
#define wdt_res()
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:93:0: note: this is the location of the previous definition
#define wdt_res() watchdogReset()
^
Collected 38 compatible libraries
Scanning dependencies...
Library Dependency Graph ( http://bit.ly/configure-pio-ldf )
|-- <DallasTemperature> v3.7.7 #ddc46fb
|   |-- <OneWire> v2.3.2
|   |-- <DS2482_OneWire> #3ef01fc
|   |   |-- <Wire> v1.0
|   |-- <ModbusMaster> v2.0.1 #4a429bf
|-- <DS2482_OneWire> #3ef01fc
|   |-- <Wire> v1.0
|-- <DmxSimple> v3.1 #62f0959
|-- <httpClient> #007e22e
|   |-- <Ethernet> v1.1.2 #238e8fc
|   |   |-- <SPI> v1.0 #8d59205
|-- <aJson> #60e5d57
|   |-- <EEPROM> v2.0
|-- <CmdArduino> #c94cd3f
|-- <ModbusMaster> v2.0.1 #4a429bf
|-- <DMXSerial> v1.3.0 #4db73b3
|-- <Ethernet> v1.1.2 #238e8fc
|   |-- <SPI> v1.0 #8d59205
|-- <SPI> v1.0 #8d59205
|-- <PubSubClient> v2.6 #f029640
|-- <Artnet> #3d39995
|   |-- <WiFi> v1.2.7
|   |   |-- <SPI> v1.0 #8d59205
|   |-- <Ethernet> v1.1.2 #238e8fc
|   |   |-- <SPI> v1.0 #8d59205
|-- <FastLED> v3.1.8
|   |-- <DmxSimple> v3.1 #62f0959
|   |-- <SoftwareSerial> v1.0
|   |-- <DMXSerial> v1.3.0 #4db73b3
|-- <EEPROM> v2.0
|-- <Wire> v1.0
Compiling .pioenvs/megaatmega2560/src/lighthub.ino.o
In file included from /home/livello/PROG/lighthub/lighthub/lighthub.ino:127:0:
lighthub/item.h: In member function 'int Item::On()':
lighthub/item.h:85:33: warning: no return statement in function returning non-void [-Wreturn-type]
inline int On (){Ctrl(CMD_ON);};
^
lighthub/item.h: In member function 'int Item::Off()':
lighthub/item.h:86:34: warning: no return statement in function returning non-void [-Wreturn-type]
inline int Off(){Ctrl(CMD_OFF);};
^
lighthub/item.h: In member function 'int Item::Toggle()':
lighthub/item.h:87:40: warning: no return statement in function returning non-void [-Wreturn-type]
inline int Toggle(){Ctrl(CMD_TOGGLE);};
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino: In function 'void callback(char*, byte*, unsigned int)':
/home/livello/PROG/lighthub/lighthub/lighthub.ino:193:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
for (int i=0;i<length;i++) {
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:203:27: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
if (t=strrchr (topic,'/')) strncpy(subtopic,t+1 , sublen-1);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino: In function 'int mqttConfigReq(int, char**)':
/home/livello/PROG/lighthub/lighthub/lighthub.ino:672:2: warning: no return statement in function returning non-void [-Wreturn-type]
}
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino: In function 'void _setConfig(int, char**)':
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: format '%x' expects argument of type 'unsigned int*', but argument 3 has type 'byte* {aka unsigned char*}' [-Wformat=]
&mac[5]) < 6)
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: format '%x' expects argument of type 'unsigned int*', but argument 4 has type 'byte* {aka unsigned char*}' [-Wformat=]
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: format '%x' expects argument of type 'unsigned int*', but argument 5 has type 'byte* {aka unsigned char*}' [-Wformat=]
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: format '%x' expects argument of type 'unsigned int*', but argument 6 has type 'byte* {aka unsigned char*}' [-Wformat=]
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: format '%x' expects argument of type 'unsigned int*', but argument 7 has type 'byte* {aka unsigned char*}' [-Wformat=]
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: format '%x' expects argument of type 'unsigned int*', but argument 8 has type 'byte* {aka unsigned char*}' [-Wformat=]
/home/livello/PROG/lighthub/lighthub/lighthub.ino:717:19: warning: unknown conversion type character 0xffffffd1 in format [-Wformat=]
/home/livello/PROG/lighthub/lighthub/lighthub.ino: In function 'int getConfig(int, char**)':
/home/livello/PROG/lighthub/lighthub/lighthub.ino:747:10: warning: unused variable 'ch' [-Wunused-variable]
char ch;
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino: In function 'void setup()':
/home/livello/PROG/lighthub/lighthub/lighthub.ino:887:28: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("help", _handleHelp);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:888:28: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("save", _saveConfig);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:889:28: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("load", _loadConfig);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:890:26: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("get",  _getConfig);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:891:26: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("set",  _setConfig);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:892:22: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("kill", _kill);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:893:30: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
cmdAdd("req", _mqttConfigReq);
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino: In function 'short int thermoSetCurTemp(char*, short int)':
/home/livello/PROG/lighthub/lighthub/lighthub.ino:1186:61: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
else if (extArray=aJson.getArrayItem(item,I_EXT))
^
/home/livello/PROG/lighthub/lighthub/lighthub.ino:1198:1: warning: no return statement in function returning non-void [-Wreturn-type]
} //proc
^
In file included from .piolibdeps/ModbusMaster/src/ModbusMaster.h:58:0,
from /home/livello/PROG/lighthub/lighthub/lighthub.ino:73:
/home/livello/PROG/lighthub/lighthub/lighthub.ino: At top level:
.piolibdeps/ModbusMaster/src/util/crc16.h:71:17: warning: 'crc16_update' defined but not used [-Wunused-function]
static uint16_t crc16_update(uint16_t crc, uint8_t a)
^
Compiling .pioenvs/megaatmega2560/lib704/DallasTemperature/OneWire.o
.piolibdeps/DallasTemperature/OneWire.cpp: In static member function 'static uint16_t OneWire::crc16(const uint8_t*, uint16_t, uint16_t)':
.piolibdeps/DallasTemperature/OneWire.cpp:571:42: error: '_crc16_update' was not declared in this scope
crc = _crc16_update(crc, input[i]);
^
In file included from .piolibdeps/DallasTemperature/OneWire.h:7:0,
from .piolibdeps/DallasTemperature/OneWire.cpp:142:
.piolibdeps/ModbusMaster/src/util/crc16.h: At global scope:
.piolibdeps/ModbusMaster/src/util/crc16.h:71:17: warning: 'uint16_t crc16_update(uint16_t, uint8_t)' defined but not used [-Wunused-function]
static uint16_t crc16_update(uint16_t crc, uint8_t a)
^
Archiving .pioenvs/megaatmega2560/libab3/libEthernet.a
Archiving .pioenvs/megaatmega2560/liba60/libhttpClient.a
Indexing .pioenvs/megaatmega2560/libab3/libEthernet.a
Indexing .pioenvs/megaatmega2560/liba60/libhttpClient.a
Compiling .pioenvs/megaatmega2560/lib9dd/aJson/utility/stringbuffer.o
Compiling .pioenvs/megaatmega2560/libf1a/CmdArduino/Cmd.o
Compiling .pioenvs/megaatmega2560/lib231/DMXSerial/DMXSerial.o
Compiling .pioenvs/megaatmega2560/lib9a2/PubSubClient/PubSubClient.o
.piolibdeps/CmdArduino/Cmd.cpp: In function 'void cmd_parse(char*)':
.piolibdeps/CmdArduino/Cmd.cpp:78:10: warning: unused variable 'buf' [-Wunused-variable]
char buf[50];
^
*** [.pioenvs/megaatmega2560/lib704/DallasTemperature/OneWire.o] Error 1
.piolibdeps/DMXSerial/src/DMXSerial.cpp:157:0: warning: "SERIAL_8N1" redefined
#define SERIAL_8N1  ((0<<USBSn) | (0<<UPMn0) | (3<<UCSZn0))
^
In file included from /home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/Arduino.h:232:0,
from .piolibdeps/DMXSerial/src/DMXSerial.cpp:25:
/home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/HardwareSerial.h:71:0: note: this is the location of the previous definition
#define SERIAL_8N1 0x06
^
.piolibdeps/DMXSerial/src/DMXSerial.cpp:158:0: warning: "SERIAL_8N2" redefined
#define SERIAL_8N2  ((1<<USBSn) | (0<<UPMn0) | (3<<UCSZn0))
^
In file included from /home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/Arduino.h:232:0,
from .piolibdeps/DMXSerial/src/DMXSerial.cpp:25:
/home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/HardwareSerial.h:75:0: note: this is the location of the previous definition
#define SERIAL_8N2 0x0E
^
.piolibdeps/DMXSerial/src/DMXSerial.cpp:159:0: warning: "SERIAL_8E1" redefined
#define SERIAL_8E1  ((0<<USBSn) | (2<<UPMn0) | (3<<UCSZn0))
^
In file included from /home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/Arduino.h:232:0,
from .piolibdeps/DMXSerial/src/DMXSerial.cpp:25:
/home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/HardwareSerial.h:79:0: note: this is the location of the previous definition
#define SERIAL_8E1 0x26
^
.piolibdeps/DMXSerial/src/DMXSerial.cpp:160:0: warning: "SERIAL_8E2" redefined
#define SERIAL_8E2  ((1<<USBSn) | (2<<UPMn0) | (3<<UCSZn0))
^
In file included from /home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/Arduino.h:232:0,
from .piolibdeps/DMXSerial/src/DMXSerial.cpp:25:
/home/livello/.platformio/packages/framework-arduinoavr/cores/arduino/HardwareSerial.h:83:0: note: this is the location of the previous definition
#define SERIAL_8E2 0x2E
^
.piolibdeps/DMXSerial/src/DMXSerial.cpp: In member function 'uint8_t DMXSerialClass::read(int)':
.piolibdeps/DMXSerial/src/DMXSerial.cpp:322:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
if (channel > _dmxMaxChannel) channel = _dmxMaxChannel;
^
.piolibdeps/DMXSerial/src/DMXSerial.cpp: In member function 'void DMXSerialClass::write(int, uint8_t)':
.piolibdeps/DMXSerial/src/DMXSerial.cpp:336:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
if (channel > _dmxMaxChannel) channel = _dmxMaxChannel;
^
.piolibdeps/DMXSerial/src/DMXSerial.cpp: In function 'void __vector_37()':
.piolibdeps/DMXSerial/src/DMXSerial.cpp:543:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
if (_dmxChannel > _dmxMaxChannel) {
^
========================================================================================= [ERROR] Took 1.53 seconds =========================================================================================

================================================================================================= [SUMMARY] =================================================================================================
Environment megaatmega2560-5500	[SKIP]
Environment megaatmega2560     	[ERROR]
Environment due                	[SKIP]
Environment due-W5500          	[SKIP]
Environment espressif8266      	[SKIP]
========================================================================================= [ERROR] Took 1.53 seconds =========================================================================================